### PR TITLE
Ppm led dimer

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -2,7 +2,7 @@
  * Controladora con ppm.cpp
  *
  * Created: 28/07/2020 19:50:39
- * Author : Usuario
+ * Author : xDzohlx
  */ 
 
 //input canal 1 pa0,


### PR DESCRIPTION
Se agrego un dimer al led de estado utilizando el timer del control de los motores con pwm controlado por software por lo que se puede cambiar a cualquier pin, utilizando una frecuencia 65000 veces menor para tener una frecuencia aproximada de 1/2 hertz